### PR TITLE
Exposing secretbox methods for use with nonce. 

### DIFF
--- a/NAChloride/NASecretBox.h
+++ b/NAChloride/NASecretBox.h
@@ -15,6 +15,10 @@
 
 - (NSData *)encrypt:(NSData *)data key:(NSData *)key error:(NSError * __autoreleasing *)error;
 
+- (NSData *)encrypt:(NSData *)data nonce:(NSData *)nonce key:(NSData *)key authenticated:(BOOL)useAuth error:(NSError * __autoreleasing *)error;
+
 - (NSData *)decrypt:(NSData *)data key:(NSData *)key error:(NSError * __autoreleasing *)error;
+
+- (NSData *)decrypt:(NSData *)data nonce:(NSData *)nonce key:(NSData *)key authenticated:(BOOL)useAuth error:(NSError * __autoreleasing *)error;
 
 @end

--- a/NAChloride/NASecretBox.m
+++ b/NAChloride/NASecretBox.m
@@ -14,6 +14,20 @@
 
 @implementation NASecretBox
 
+
+
+- (NSData *)decrypt:(NSData *)data nonce:(NSData *)nonce key:(NSData *)key authenticated:(BOOL)useAuth error:(NSError * __autoreleasing *)error {
+    
+  NSData *encryptedData = nil;
+  if (useAuth) {
+      encryptedData = [self decryptAuthenticated:data nonce:nonce key:key error:error];
+  }else{
+      encryptedData = [self decrypt:data nonce:nonce key:key error:error];
+  }
+    
+  return encryptedData;
+}
+
 - (NSData *)decrypt:(NSData *)data key:(NSData *)key error:(NSError * __autoreleasing *)error {
   if (!data || [data length] < crypto_secretbox_noncebytes()) {
     if (error) *error = [NSError errorWithDomain:@"NAChloride" code:200 userInfo:@{NSLocalizedDescriptionKey: @"Invalid data"}];
@@ -50,6 +64,36 @@
   return [NSData dataWithBytes:([outData bytes] + crypto_secretbox_zerobytes())
                         length:([outData length] - crypto_secretbox_zerobytes())];
 }
+
+- (NSData *)decryptAuthenticated:(NSData *)encryptedData nonce:(NSData *)nonce key:(NSData *)key error:(NSError * __autoreleasing *)error {
+  NSMutableData *outData = [NSMutableData dataWithLength:[encryptedData length]];
+    
+  int retval = crypto_secretbox_open_easy([outData mutableBytes],
+                                          [encryptedData bytes], [encryptedData length],
+                                          [nonce bytes], [key bytes]);
+  if (retval == -1) {
+      if (error) *error = [NSError errorWithDomain:@"NAChloride" code:205 userInfo:@{NSLocalizedDescriptionKey: @"Verification during decryption failed"}];
+      return nil;
+  }
+    
+    // Remove MACBYTES from outdata
+  return [NSData dataWithBytes:[outData bytes]
+                        length:([outData length] - crypto_secretbox_macbytes())];
+}
+
+
+- (NSData *)encrypt:(NSData *)data nonce:(NSData *)nonce key:(NSData *)key authenticated:(BOOL)useAuth error:(NSError * __autoreleasing *)error {
+    
+  NSData *encryptedData = nil;
+  if (useAuth) {
+    encryptedData = [self encryptAuthenticated:data nonce:nonce key:key error:error];
+  }else{
+    encryptedData = [self encrypt:data nonce:nonce key:key error:error];
+  }
+    
+  return encryptedData;
+}
+
 
 - (NSData *)encrypt:(NSData *)data key:(NSData *)key error:(NSError * __autoreleasing *)error {
   NSData *nonce = [NARandom randomData:crypto_secretbox_noncebytes() error:error];
@@ -95,6 +139,35 @@
   // Remove BOXZEROBYTES from out data
   return [NSData dataWithBytes:([outData bytes] + crypto_secretbox_boxzerobytes())
                         length:([outData length] - crypto_secretbox_boxzerobytes())];
+}
+
+- (NSData *)encryptAuthenticated:(NSData *)data nonce:(NSData *)nonce key:(NSData *)key error:(NSError * __autoreleasing *)error {
+  if (!nonce || [nonce length] != crypto_secretbox_noncebytes()) {
+      if (error) *error = [NSError errorWithDomain:@"NAChloride" code:103 userInfo:@{NSLocalizedDescriptionKey: @"Invalid nonce"}];
+      return nil;
+  }
+    
+  if (!data) {
+      if (error) *error = [NSError errorWithDomain:@"NAChloride" code:104 userInfo:@{NSLocalizedDescriptionKey: @"Invalid data"}];
+      return nil;
+  }
+    
+  if (!key || [key length] != crypto_secretbox_keybytes()) {
+      if (error) *error = [NSError errorWithDomain:@"NAChloride" code:103 userInfo:@{NSLocalizedDescriptionKey: @"Invalid key"}];
+      return nil;
+  }
+    
+  // Add space for authentication tag of size MACBYTES
+  NSMutableData *outData = [NSMutableData dataWithLength:[data length] + crypto_secretbox_macbytes()];
+    
+  int retval = crypto_secretbox_easy([outData mutableBytes],
+                                     [data bytes], [data length],
+                                     [nonce bytes],
+                                     [key bytes]);
+    
+  if (retval != 0) return nil;
+    
+  return outData;
 }
 
 

--- a/README.md
+++ b/README.md
@@ -37,6 +37,8 @@ NAChlorideInit();
 
 (via libsodium)
 
+The simple `encrypt` method will implicitly generate nonce and concatenate nonce + the ciphertext to one NSData object and does not add MAC authenticaton. The simple `decrypt` will handle it accordingly.
+
 ```objc
 NSData *key = [NARandom randomData:NASecretBoxKeySize error:&error];
 NSData *message = [@"This is a secret message" dataUsingEncoding:NSUTF8StringEncoding];
@@ -46,6 +48,22 @@ NSData *encrypted = [secretBox encrypt:message key:key error:&error];
 // If an error occurred encrypted will be nil and error set
 
 NSData *decrypted = [secretBox decrypt:encrypted key:key error:&error];
+```
+Utilizing all parameters crypto\_secretbox and crypto\_secretbox\_easy can be used.
+Passing `YES` to the `authenticated` parameter will result in using crypto\_secretbox\_easy with MAC authenticaton (recommended).
+
+```objc
+NSData *key = [NARandom randomData:NASecretBoxKeySize error:&error];
+NSData *nonce = [NARandom randomData:NASecretBoxNonceSize error:nil];
+NSData *message = [@"This is a secret message" dataUsingEncoding:NSUTF8StringEncoding];
+
+NASecretBox *secretBox = [[NASecretBox alloc] init];
+NSData *encrypted = [secretBox encrypt:message nonce:nonce key:key authenticated:YES error:&error];
+// If an error occurred encrypted will be nil and error set
+
+NSData *decrypted = [secretBox decrypt:encrypted nonce:nonce key:key authenticated:YES error:&error];
+// If the encrypted message has been tampered with before decrypting it an error is set
+
 ```
 
 # Scrypt

--- a/Tests/NASecretBoxTest.m
+++ b/Tests/NASecretBoxTest.m
@@ -38,4 +38,30 @@
   GRTestLog(@"Error: %@", error);
 }
 
+- (void)testEncryptAuthenticated {
+    NAChlorideInit();
+    
+    NSData *key = [NARandom randomData:NASecretBoxKeySize error:nil];
+    NSData *nonce = [NARandom randomData:NASecretBoxNonceSize error:nil];
+    NSData *message = [@"This is a secret message" dataUsingEncoding:NSUTF8StringEncoding];
+    
+    NASecretBox *secretBox = [[NASecretBox alloc] init];
+    NSData *encryptedData = [secretBox encrypt:message nonce:nonce key:key authenticated:YES error:nil];
+    NSData *decryptedData = [secretBox decrypt:encryptedData nonce:nonce key:key authenticated:YES error:nil];
+    GRAssertEqualObjects(message, decryptedData);
+}
+
+- (void)testEncryptAuthenticatedError {
+    NSData *badKey = [NSData data];
+    NSError *error = nil;
+    NASecretBox *secretBox = [[NASecretBox alloc] init];
+    NSData *nonce = [NARandom randomData:NASecretBoxNonceSize error:nil];
+    NSData *encryptedData = [secretBox encrypt:[@"This is a secret" dataUsingEncoding:NSUTF8StringEncoding] nonce:nonce key:badKey authenticated:YES error:&error];
+    GRAssertNil(encryptedData);
+    GRAssertNotNil(error);
+    GRAssertEquals((NSInteger)103, error.code);
+    GRTestLog(@"Error: %@", error);
+}
+
+
 @end


### PR DESCRIPTION
+ Support libsodiums crypto_secretbox_easy with authentication tag (MAC) validation optionally.